### PR TITLE
Adding Topological Lines to the map

### DIFF
--- a/src/Map.jsx
+++ b/src/Map.jsx
@@ -51,7 +51,7 @@ const Map = () => {
     const map = new mapboxgl.Map({
       
       container: mapContainerRef.current,
-      style: "mapbox://styles/mapbox/streets-v11",
+      style: "mapbox://styles/mapbox/outdoors-v11",
       center: [13, 43],
       zoom: 5,
       maxBounds: [[4.91306038378405, 36.08567211105813], [19.225508855943896, 48.79804811867416]]


### PR DESCRIPTION
By changing the style of the map, you can now see the topological lines of the environment if you are zoomed far enough into an area